### PR TITLE
tag newly created groups 'active'

### DIFF
--- a/cocaine/tools/tags.py
+++ b/cocaine/tools/tags.py
@@ -4,4 +4,4 @@ __author__ = 'Evgeny Safronov <division494@gmail.com>'
 APPS_TAGS = ('app',)
 RUNLISTS_TAGS = ('runlist',)
 PROFILES_TAGS = ('profile',)
-GROUPS_TAGS = ('group',)
+GROUPS_TAGS = ('group', 'active')


### PR DESCRIPTION
gateway routes only groups tagged ('group', 'active').
Without this fix one can not actually add and manage working routing groups.

Probably, we should instead have some kind of `activate`/`deactivate` group commands.
