### PR TITLE
Fix owner for directory with pid-files

### DIFF
--- a/debian/cocaine-tornado-proxy.init
+++ b/debian/cocaine-tornado-proxy.init
@@ -32,6 +32,7 @@ if [ ! -d "$PID_PATH" ]; then
   # Control will enter here if $DIRECTORY exists.
   echo "Create $PID_PATH"
   mkdir -p $PID_PATH
+  chown $USER $PID_PATH
 fi
 
 do_start()


### PR DESCRIPTION
After server reboot $PID_PATH creates with root owner. But cocaine-tornado-proxy after forks work under $USER and have no access to $PID_PATH.
