### PR TITLE
[Crashlog] Support date query in crashlog.List

### DIFF
--- a/cocaine/tools/dispatcher.py
+++ b/cocaine/tools/dispatcher.py
@@ -608,14 +608,16 @@ def crashlog_status(options):
 
 @crashlogDispatcher.command(name='list')
 def crashlog_list(options,
-                  name=('n', '', 'name')):
+                  name=('n', '', 'name'),
+                  day=('d', '', 'day')):
     """Show crashlogs list for application.
 
     Prints crashlog list in timestamp - uuid format.
     """
     options.executor.executeAction('crashlog:list', **{
         'storage': options.getService('storage'),
-        'name': name
+        'name': name,
+        'day_string': day,
     })
 
 


### PR DESCRIPTION
Right now crashlogs indexed by day. So listing should support this index.
Idea:
```bash
cocaine-tool crashlog list -n app -d yesterday  # crashlogs from yesterday
cocaine-tool crashlog list -n app -d today  # fresh crashlogs
cocaine-tool crashlog list -n app -d 30  # for 30 of the current month
cocaine-tool crashlog list -n app -d 30-12  # for 30-12 of the current year
cocaine-tool crashlog list -n app -d 30-12-1988  # the whole date
```
Specific words ```today``` and ``yesterday``` can be provided partly like ```t``` or ```ye```