### PR TITLE
debian/changelog and setup.py versions are same

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ else:
 
 setup(
     name="cocaine-tools",
-    version="0.11.7.5",
+    version="0.11.7.6",
     author="Anton Tyurin",
     author_email="noxiouz@yandex.ru",
     maintainer='Evgeny Safronov',

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 import logging
 import os
+import re
 import sys
 import unittest
 
@@ -719,6 +720,42 @@ class HTTPUnixClientTestCase(AsyncHTTPTestCase):
         http_client.fetch("http://localhost", self.stop)
         response = self.wait()
         self.assertEqual(200, response.code)
+
+
+class TestMisc(unittest.TestCase):
+    def test_versions(self):
+        '''
+        Check that latest version in debian/changelog matches version from setup.py
+        '''
+        setup_dict = {}
+
+        def patched_setup(**kwargs):
+            setup_dict.update(kwargs)
+
+        import setuptools
+        original_setup = setuptools.setup
+
+        setup_py = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..', 'setup.py'))
+
+        try:
+            setuptools.setup = patched_setup
+            execfile(setup_py, {'__file__': setup_py, '__name__': '__main__'}, {})
+        finally:
+            setuptools.setup = original_setup
+
+        setup_py_version = setup_dict['version']
+
+        debian_changelog = os.path.join(os.path.dirname(__file__), '..',
+                                        'debian', 'changelog')
+        with open(debian_changelog) as f:
+            changelog_firstline = f.readline()
+
+        match = re.match(r'^cocaine-tools \(([^)]+)\) .*$', changelog_firstline)
+        debian_changelog_version = match.group(1)
+
+        self.assertEqual(setup_py_version, debian_changelog_version)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Often version in setup.py differs from version in debian/changelog. It confuses me and I can't exactly know which version I install.

This test checks that versions are the same.