### PR TITLE
feat(sampling): make sampling configurable via Unicorn

### DIFF
--- a/cocaine/proxy/proxy.py
+++ b/cocaine/proxy/proxy.py
@@ -421,7 +421,7 @@ class CocaineProxy(object):
             self.logger.info("stop watching for sampling updates of %s", name)
             self.sampled_apps.pop(name, None)
             try:
-                watch_channel.close()
+                watch_channel.tx.close()
             except Exception:
                 pass
 

--- a/cocaine/tools/actions/tracing.py
+++ b/cocaine/tools/actions/tracing.py
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2013+ Anton Tyurin <noxiouz@yandex.ru>
+# Copyright (c) 2013+ Evgeny Safronov <division494@gmail.com>
+# Copyright (c) 2011-2014 Other contributors as noted in the AUTHORS file.
+#
+# This file is part of Cocaine-tools.
+#
+# Cocaine is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# Cocaine is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+
+from tornado import gen
+
+from cocaine.tools.error import ToolsError
+
+
+class TracingConfigurator(object):
+    def __init__(self, configuration_service, path="/zipkin_sampling"):
+        self.configuration_service = configuration_service
+        self.path = path
+
+    @gen.coroutine
+    def execute(self):
+        raise NotImplementedError
+
+
+class TracingConfigRemove(TracingConfigurator):
+    def __init__(self, name, configuration_service, path="/zipkin_sampling"):
+        super(TracingConfigRemove, self).__init__(configuration_service, path)
+        self.name = name
+
+    @gen.coroutine
+    def execute(self):
+        abs_node_path = os.path.join(self.path, self.name)
+        removed = yield (yield self.configuration_service.remove(abs_node_path, 0)).rx.get()
+        if not removed:
+            raise ToolsError("the value at %s was not removed" % (abs_node_path))
+
+
+class TracingConfigView(TracingConfigurator):
+    def __init__(self, configuration_service, path="/zipkin_sampling", name=None):
+        super(TracingConfigView, self).__init__(configuration_service, path)
+        self.name = name
+
+    @gen.coroutine
+    def execute(self):
+        if self.name:
+            res = yield self.specific(self.name)
+            raise gen.Return(res)
+        else:
+            listing_channel = yield self.configuration_service.children_subscribe(self.path)
+            _, listing = yield listing_channel.rx.get()
+            listing_channel.tx.close()
+            res = {}
+            for node in listing:
+                node_res = yield self.specific(node)
+                res[node] = node_res
+            raise gen.Return(res)
+
+    @gen.coroutine
+    def specific(self, name):
+        channel = yield self.configuration_service.get(os.path.join(self.path, name))
+        version, value = yield channel.rx.get()
+        raise gen.Return({"version": version, "value": value})
+
+
+def convert_tracing_config_value(value):
+    try:
+        return float(value)
+    except ValueError as err:
+        raise ToolsError("value %s must be convertable to float: %s" % (value, err))
+
+
+class TracingConfigStore(TracingConfigurator):
+    def __init__(self, name, value, configuration_service, path="/zipkin_sampling"):
+        super(TracingConfigStore, self).__init__(configuration_service, path)
+        self.name = name
+        self.value = convert_tracing_config_value(value)
+
+    @gen.coroutine
+    def execute(self):
+        abs_node_path = os.path.join(self.path, self.name)
+        channel = yield self.configuration_service.create(abs_node_path, self.value)
+        created = yield channel.rx.get()
+        if not created:
+            try:
+                version, _ = yield (yield self.configuration_service.get(abs_node_path)).rx.get()
+                saved, _ = yield (yield self.configuration_service.put(abs_node_path, self.value, version))
+                if not saved:
+                    raise ToolsError("the value was not stored to %s" % (abs_node_path))
+            except Exception as err:
+                raise ToolsError("unable to store value at %s: %s" % (abs_node_path, err))

--- a/cocaine/tools/cli.py
+++ b/cocaine/tools/cli.py
@@ -29,7 +29,7 @@ from tornado.ioloop import IOLoop
 from cocaine.exceptions import ChokeEvent, CocaineError
 from cocaine.decorators import coroutine
 from cocaine.tools import log, interactive
-from cocaine.tools.actions import common, app, profile, runlist, crashlog, group
+from cocaine.tools.actions import common, app, profile, runlist, crashlog, group, tracing
 from cocaine.tools.error import ToolsError
 
 
@@ -175,6 +175,10 @@ NG_ACTIONS = {
     'crashlog:removeall': ToolHandler(crashlog.RemoveAll),
     'crashlog:clean': ToolHandler(crashlog.Clean),
     'crashlog:cleanwhen': ToolHandler(crashlog.CleanRange),
+
+    'tracing:view': JsonToolHandler(tracing.TracingConfigView),
+    'tracing:store': ToolHandler(tracing.TracingConfigStore),
+    'tracing:remove': ToolHandler(tracing.TracingConfigRemove),
 }
 
 

--- a/cocaine/tools/dispatcher.py
+++ b/cocaine/tools/dispatcher.py
@@ -134,6 +134,7 @@ class dispatcher(object):
 profileDispatcher = Dispatcher(globaloptions=Global.options, middleware=middleware)
 runlistDispatcher = Dispatcher(globaloptions=Global.options, middleware=middleware)
 crashlogDispatcher = Dispatcher(globaloptions=Global.options, middleware=middleware)
+tracingDispatcher = Dispatcher(globaloptions=Global.options, middleware=middleware)
 
 
 @d.command(name='locate', usage='[--name=NAME]')
@@ -832,8 +833,38 @@ def group_edit(options,
         'name': name,
     })
 
+
+@tracingDispatcher.command(name='store', usage='-n NAME -v VALUE')
+def tracing_store(options,
+                  name=('n', '', 'node name'),
+                  value=('v', '', 'valuer')):
+    options.executor.executeAction('tracing:store', **{
+        'configuration_service': options.getService('unicorn'),
+        'name': name,
+        'value': value,
+    })
+
+
+@tracingDispatcher.command(name='remove', usage='-n NAME')
+def tracing_remove(options,
+                   name=('n', '', 'node name')):
+    options.executor.executeAction('tracing:remove', **{
+        'configuration_service': options.getService('unicorn'),
+        'name': name,
+    })
+
+
+@tracingDispatcher.command(name='view', usage='-n NAME')
+def tracing_view(options,
+                 name=('n', '', 'node name')):
+    options.executor.executeAction('tracing:view', **{
+        'configuration_service': options.getService('unicorn'),
+        'name': name,
+    })
+
 d.nest('app', appDispatcher, 'application commands')
 d.nest('profile', profileDispatcher, 'profile commands')
 d.nest('runlist', runlistDispatcher, 'runlist commands')
 d.nest('crashlog', crashlogDispatcher, 'crashlog commands')
 d.nest('group', dispatcher.group, 'routing group commands')
+d.nest('tracing', tracingDispatcher, 'tracing configuration commands')


### PR DESCRIPTION
Chance to be traced for each app can be individually tuned via
Unicorn service. The proxy subscribes on updates and uses default
`tracing` chance for non-configured apps.

A configuration tree:
```
/zipkin-sampling
                /App1 <- non-negative float
                /App2 <- non-negative float
```