### PR TITLE
feat: trace bit support

### DIFF
--- a/cocaine/proxy/proxy.py
+++ b/cocaine/proxy/proxy.py
@@ -159,6 +159,7 @@ def context(func):
             else:
                 request.logger = NULLLOGGER  # pylint: disable=R0204
             request.traceid = traceid
+            request.tracebit = True
             request.logger.info("start request: %s %s %s", request.host, request.remote_ip, request.uri)
             yield func(self, request)
         finally:
@@ -564,7 +565,7 @@ class CocaineProxy(object):
             if tracing_chance < rolled_dice:
                 request.logger.info('stop tracing the request')
                 request.logger = NULLLOGGER
-                request.traceid = None
+                request.tracebit = False
 
         if self.sticky_header in request.headers:
             seed = request.headers.get(self.sticky_header)
@@ -643,7 +644,9 @@ class CocaineProxy(object):
         else:
             trace = None
 
-        headers = {}
+        headers = {
+            'trace_bit': '{:d}'.format(request.tracebit),
+        }
         if 'authorization' in request.headers:
             headers['authorization'] = request.headers['authorization']
 

--- a/cocaine/tools/version.py
+++ b/cocaine/tools/version.py
@@ -19,4 +19,4 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-__version__ = "0.12.12.28"
+__version__ = "0.12.12.29"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-tools (0.12.12.29) unstable; urgency=low
+
+  * [Proxy] Trace bit support.
+
+ -- Evgeny Safronov <division494@gmail.com>  Fri, 10 Mar 2017 18:06:41 +0300
+
 cocaine-tools (0.12.12.28) unstable; urgency=low
 
   * [Proxy] Forward authorization headers.


### PR DESCRIPTION
This commit changes meaning of a tracing chance, which now sets a special `trace_bit` header without resetting a trace id making forwarding of all tracing headers into the Cocaine and so on.

Requires simultaneous merge of a https://github.com/3Hren/cocaine-core/pull/150 and https://github.com/cocaine/cocaine-framework-python/pull/55.